### PR TITLE
Misha/several enhancements

### DIFF
--- a/plutip.cabal
+++ b/plutip.cabal
@@ -48,6 +48,7 @@ common common-imports
     , plutus-pab
     , plutus-tx
     , plutus-tx-plugin
+    , retry
     , row-types
     , servant-client
     , stm
@@ -130,6 +131,7 @@ library
 
 executable plutip-example
   import:         common-language
+  import:         common-ghc-options
   main-is:        Main.hs
   other-modules:
     DebugContract.GetUtxos

--- a/plutip.cabal
+++ b/plutip.cabal
@@ -55,6 +55,7 @@ common common-imports
     , tasty
     , text
     , text-class
+    , transformers-except
     , typed-process
     , uuid
 

--- a/test/Spec/Integration.hs
+++ b/test/Spec/Integration.hs
@@ -23,7 +23,7 @@ import Test.Plutip (
   runUsingCluster,
   waitSeconds,
  )
-import Test.Plutip.Internal.LocalCluster.Types (isSuccess)
+import Test.Plutip.Internal.LocalCluster.Types (isContractError, isException, isSuccess)
 import Test.Plutip.Tools.CardanoApi (utxosAtAddress)
 import Test.Tasty (TestTree)
 import Test.Tasty.HUnit (assertBool, assertFailure, testCase, (@?=))
@@ -43,10 +43,10 @@ test = do
       assertSucceeds
         "Get utxos"
         (runContract w1 getUtxos)
-      assertFails
+      assertContractError
         "Get utxos throwing error"
         (runContract w1 getUtxosThrowsErr)
-      assertFails
+      assertException
         "Get utxos throwing exception"
         (runContract w1 getUtxosThrowsEx)
       assertFails
@@ -69,6 +69,12 @@ test = do
 
     assertFails tag act = do
       act >>= liftIO . assertBool (tag <> " did not fail") . not . isSuccess
+
+    assertContractError tag act = do
+      act >>= liftIO . assertBool (tag <> " did not throw Contract error") . isContractError
+
+    assertException tag act = do
+      act >>= liftIO . assertBool (tag <> " did not throw exception") . isException
 
     checkAdaTxFromTo w1 w2 = do
       res <- runContract w1 (payTo (ledgerPaymentPkh w2) 10_000_000)

--- a/test/Spec/Integration.hs
+++ b/test/Spec/Integration.hs
@@ -22,7 +22,6 @@ import Test.Plutip (
   runContract,
   runUsingCluster,
   waitSeconds,
-  ledgerPaymentPkh,
  )
 import Test.Plutip.Internal.LocalCluster.Types (isSuccess)
 import Test.Plutip.Tools.CardanoApi (utxosAtAddress)


### PR DESCRIPTION
This PR adds couple enhancements:
- no more potentially infinite waiting for relay node
- imports cleanup of cluster module (linter suppression removed)
- `RunResult` now returns contract state even in case of failure (as state can change before the failure, and user could be potentially interested in it); couple checks for `RunResult` added to make tests more precise