### PR TITLE
helper function to get socket path from

### DIFF
--- a/src/Test/Plutip/Internal/Types.hs
+++ b/src/Test/Plutip/Internal/Types.hs
@@ -4,11 +4,13 @@ module Test.Plutip.Internal.Types (
   FailureReason (..),
   RunningNode (..),
   nodeSocket,
+  nodeConfig,
   isExecutionError,
   isException,
   isSuccessful,
 ) where
 
+import Paths_plutip ( getDataFileName )
 import Cardano.Api (NetworkId)
 import Cardano.BM.Tracing (Trace)
 import Cardano.Launcher.Node (CardanoNodeConn)
@@ -34,6 +36,10 @@ data ClusterEnv = ClusterEnv
 -- | Helper function to get socket path from
 nodeSocket :: ClusterEnv -> CardanoNodeConn
 nodeSocket (ClusterEnv (RunningNode sp _ _) _ _ _ _ _) = sp
+
+-- | Helper function to get node config path from
+nodeConfig :: IO FilePath
+nodeConfig = getDataFileName "cluster-data/node.config"
 
 -- | Result of `Contract` execution. Returns contract observable state
 --    and either `Contract` return value, or error of type `FailureReason`.


### PR DESCRIPTION
Would it make sense to add this helper function so projects using Plutip can connect services like Kupo that require the node config and socket to function properly?