### PR TITLE
Resolves #50

### DIFF
--- a/src/Test/Plutip/Contract.hs
+++ b/src/Test/Plutip/Contract.hs
@@ -113,6 +113,7 @@ module Test.Plutip.Contract (
   ValueOrdering (VEq, VGt, VLt, VGEq, VLEq),
   assertValues,
   assertExecution,
+  ada,
 ) where
 
 import Control.Arrow (left)
@@ -362,7 +363,7 @@ newtype TestWallets = TestWallets {unTestWallets :: NonEmpty TestWallet}
   deriving newtype (Semigroup)
 
 data TestWallet = TestWallet
-  { twInitDistribuition :: Positive
+  { twInitDistribuition :: [Positive]
   , twExpected :: Maybe (ValueOrdering, Value)
   }
 
@@ -376,74 +377,80 @@ compareValuesWith VLt = Value.lt
 compareValuesWith VGEq = Value.geq
 compareValuesWith VLEq = Value.leq
 
--- | Create a wallet with the given amount of lovelace.
+-- | Create a wallet with the given amounts of lovelace.
+--  Each amount will be sent to address as separate UTXO.
 --
 -- @since 0.2
-initLovelace :: Positive -> TestWallets
+initLovelace :: [Positive] -> TestWallets
 initLovelace initial = TestWallets $ TestWallet initial Nothing :| []
 
--- | Create a wallet with the given amount of lovelace, and after contract execution
+-- | Create a wallet with the given amounts of lovelace, and after contract execution
 -- compare the values at the wallet address with the given ordering and value.
 --
 -- @since 0.2
-initLovelaceAssertValueWith :: Positive -> ValueOrdering -> Value -> TestWallets
+initLovelaceAssertValueWith :: [Positive] -> ValueOrdering -> Value -> TestWallets
 initLovelaceAssertValueWith initial ord expect = TestWallets $ TestWallet initial (Just (ord, expect)) :| []
 
--- | Create a wallet with the given amount of lovelace, and after contract execution
+-- | Create a wallet with the given amounts of lovelace, and after contract execution
 -- check if values at the wallet address are equal to a given value.
 --
 -- @since 0.2
-initLovelaceAssertValue :: Positive -> Value -> TestWallets
+initLovelaceAssertValue :: [Positive] -> Value -> TestWallets
 initLovelaceAssertValue initial = initLovelaceAssertValueWith initial VEq
 
--- | Create a wallet with the given amount of lovelace, and after contract execution
+-- | Create a wallet with the given amounts of lovelace, and after contract execution
 -- compare the values at the wallet address with the given ordering and lovelace amount.
 --
 -- @since 0.2
-initAndAssertLovelaceWith :: Positive -> ValueOrdering -> Positive -> TestWallets
+initAndAssertLovelaceWith :: [Positive] -> ValueOrdering -> Positive -> TestWallets
 initAndAssertLovelaceWith initial ord expect =
   initLovelaceAssertValueWith initial ord (Ada.lovelaceValueOf (fromIntegral expect))
 
--- | Create a wallet with the given amount of lovelace, and after contract execution
+-- | Create a wallet with the given amounts of lovelace, and after contract execution
 -- check if values at the wallet address are equal to a given lovelace amount.
 --
 -- @since 0.2
-initAndAssertLovelace :: Positive -> Positive -> TestWallets
+initAndAssertLovelace :: [Positive] -> Positive -> TestWallets
 initAndAssertLovelace initial expect =
   initLovelaceAssertValue initial (Ada.lovelaceValueOf (fromIntegral expect))
 
--- | Create a wallet with the given amount of Ada.
+-- | Create a wallet with the given amounts of Ada.
 --
 -- @since 0.2
-initAda :: Positive -> TestWallets
-initAda initial = initLovelace (initial * 1_000_000)
+initAda :: [Positive] -> TestWallets
+initAda initial = initLovelace (map ada initial)
 
--- | Create a wallet with the given amount of Ada, and after contract execution
+-- | Create a wallet with the given amounts of Ada, and after contract execution
 -- compare the values at the wallet address with the given ordering and value.
 --
 -- @since 0.2
-initAdaAssertValueWith :: Positive -> ValueOrdering -> Value -> TestWallets
-initAdaAssertValueWith initial = initLovelaceAssertValueWith (initial * 1_000_000)
+initAdaAssertValueWith :: [Positive] -> ValueOrdering -> Value -> TestWallets
+initAdaAssertValueWith initial = initLovelaceAssertValueWith (map ada initial)
 
--- | Create a wallet with the given amount of Ada, and after contract execution
+-- | Create a wallet with the given amounts of Ada, and after contract execution
 -- check if values at the wallet address are equal to a given value.
 --
 -- @since 0.2
-initAdaAssertValue :: Positive -> Value -> TestWallets
-initAdaAssertValue initial = initLovelaceAssertValue (initial * 1_000_000)
+initAdaAssertValue :: [Positive] -> Value -> TestWallets
+initAdaAssertValue initial = initLovelaceAssertValue (map ada initial)
 
--- | Create a wallet with the given amount of Ada, and after contract execution
+-- | Create a wallet with the given amounts of Ada, and after contract execution
 -- compare the values at the wallet address with the given ordering and ada amount.
 --
 -- @since 0.2
-initAndAssertAdaWith :: Positive -> ValueOrdering -> Positive -> TestWallets
+initAndAssertAdaWith :: [Positive] -> ValueOrdering -> Positive -> TestWallets
 initAndAssertAdaWith initial ord expect =
-  initAndAssertLovelaceWith (initial * 1_000_000) ord (expect * 1_000_000)
+  initAndAssertLovelaceWith (map ada initial) ord (ada expect)
 
--- | Create a wallet with the given amount of Ada, and after contract execution
+-- | Create a wallet with the given amounts of Ada, and after contract execution
 -- check if values at the wallet address are equal to a given ada amount.
 --
 -- @since 0.2
-initAndAssertAda :: Positive -> Positive -> TestWallets
+initAndAssertAda :: [Positive] -> Positive -> TestWallets
 initAndAssertAda initial expect =
-  initAndAssertLovelace (initial * 1_000_000) (expect * 1_000_000)
+  initAndAssertLovelace (map ada initial) (ada expect)
+
+-- | Library functions works with amounts in `Lovelace`.
+-- This function helps to specify amounts in `Ada` easier.
+ada :: Positive -> Positive
+ada = (* 1_000_000)

--- a/src/Test/Plutip/LocalCluster.hs
+++ b/src/Test/Plutip/LocalCluster.hs
@@ -18,7 +18,7 @@ import Data.Default (def)
 import Data.List.NonEmpty (NonEmpty)
 import Numeric.Natural (Natural)
 import Test.Plutip.Config (PlutipConfig)
-import Test.Plutip.Contract (TestWallet (twInitDistribuition), TestWallets (unTestWallets))
+import Test.Plutip.Contract (TestWallet (twInitDistribuition), TestWallets (unTestWallets), ada)
 import Test.Plutip.Internal.BotPlutusInterface.Wallet (
   BpiWallet,
   addSomeWallet,
@@ -28,7 +28,6 @@ import Test.Plutip.Internal.BotPlutusInterface.Wallet (
  )
 import Test.Plutip.Internal.LocalCluster (startCluster, stopCluster)
 import Test.Plutip.Internal.Types (ClusterEnv)
-import Test.Plutip.Tools (ada)
 import Test.Tasty (testGroup, withResource)
 import Test.Tasty.Providers (TestTree)
 

--- a/src/Test/Plutip/Tools.hs
+++ b/src/Test/Plutip/Tools.hs
@@ -1,15 +1,8 @@
 module Test.Plutip.Tools (
-  ada,
   waitSeconds,
 ) where
 
 import Control.Concurrent (threadDelay)
-import Numeric.Natural (Natural)
-
--- | Library functions works with amounts in `Lovelace`.
--- This function helps to specify amounts in `Ada` easier.
-ada :: Natural -> Natural
-ada = (* 1_000_000)
 
 -- | Suspend execution for n seconds (via `threadDelay`)
 waitSeconds :: Int -> IO ()


### PR DESCRIPTION
- ablility to specify list of utxos on wallet initiation
- some formatting ond redundant commetn removal

Wallet initialization functions now accept list of values, instead of single value. Each value specified in list will be sent to wallet's address as separate UTXO. 

This example will create 11 UTXOs at wallet address:
```
initAda (100 : replicate 10 7)
``` 