### PR TITLE
Throw error and close resource correctly

### DIFF
--- a/src/Test/Plutip/Internal/LocalCluster.hs
+++ b/src/Test/Plutip/Internal/LocalCluster.hs
@@ -50,7 +50,7 @@ import Test.Plutip.Internal.Types (
   RunningNode (RunningNode),
  )
 import Test.Plutip.Tools.CardanoApi qualified as Tools
-import UnliftIO.Concurrent (forkFinally)
+import UnliftIO.Concurrent (forkFinally, myThreadId, throwTo)
 import UnliftIO.Exception (bracket, catchIO, finally)
 import UnliftIO.STM (TVar, atomically, newTVarIO, readTVar, retrySTM, writeTVar)
 
@@ -72,6 +72,7 @@ startCluster ::
   IO (TVar (ClusterStatus a), a)
 startCluster conf onClusterStart = do
   status <- newTVarIO ClusterStarting
+  tid <- myThreadId
   void $
     forkFinally
       ( withPlutusInterface conf $ \clusterEnv -> do
@@ -79,7 +80,10 @@ startCluster conf onClusterStart = do
           atomically $ writeTVar status (ClusterStarted res)
           atomically $ readTVar status >>= \case ClusterClosing -> pure (); _ -> retrySTM
       )
-      (either (error . show) (const (atomically (writeTVar status ClusterClosed))))
+      ( \e -> do
+          atomically (writeTVar status ClusterClosed)
+          either (throwTo tid) pure e
+      )
 
   setupRes <- atomically $ readTVar status >>= \case ClusterStarted v -> pure v; _ -> retrySTM
   pure (status, setupRes)

--- a/src/Test/Plutip/Internal/LocalCluster.hs
+++ b/src/Test/Plutip/Internal/LocalCluster.hs
@@ -80,9 +80,9 @@ startCluster conf onClusterStart = do
           atomically $ writeTVar status (ClusterStarted res)
           atomically $ readTVar status >>= \case ClusterClosing -> pure (); _ -> retrySTM
       )
-      ( \e -> do
+      ( \result -> do
           atomically (writeTVar status ClusterClosed)
-          either (throwTo tid) pure e
+          either (throwTo tid) pure result
       )
 
   setupRes <- atomically $ readTVar status >>= \case ClusterStarted v -> pure v; _ -> retrySTM


### PR DESCRIPTION
The tests seem to hang if an error is ever thrown in the setup. I believe it was due to not handling the raised error explicitly, so I added a handler that propagates the error to the parent thread.