### PR TITLE
flake: use makeWrapper to add cardano-cli/-node to PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Cardano tool to spin up private network and run Plutus contracts on it
 
 ## Requirements
 
-Current version of `Plutip` requires some initial setup to be prepared to function properly:
+If your project is importing and making use of `Plutip`s library you will need to make sure that the following executables are present in your `PATH`:
 
 - `cardano-cli` executable available in the environment
 - `cardano-node` executable available in the environment

--- a/flake.nix
+++ b/flake.nix
@@ -36,11 +36,27 @@
       }];
 
       haskellModules = bot-plutus-interface.haskellModules ++ [
-        ({ config, ... }: {
-          packages.plutip.components.tests."plutip-tests".build-tools = [
-            config.hsPkgs.cardano-cli.components.exes.cardano-cli
-            config.hsPkgs.cardano-node.components.exes.cardano-node
-          ];
+        ({ config, pkgs, ... }:{
+          packages.plutip.components.tests.plutip-tests = {
+            pkgconfig = [[ pkgs.makeWrapper ]];
+            postInstall = with pkgs; ''
+              wrapProgram $out/bin/plutip-tests \
+                --prefix PATH : "${lib.makeBinPath [
+                  config.hsPkgs.cardano-cli.components.exes.cardano-cli
+                  config.hsPkgs.cardano-node.components.exes.cardano-node
+                ]}"
+            '';
+          };
+          packages.plutip.components.exes.local-cluster = {
+            pkgconfig = [[ pkgs.makeWrapper ]];
+            postInstall = with pkgs; ''
+              wrapProgram $out/bin/local-cluster \
+                --prefix PATH : "${lib.makeBinPath [
+                  config.hsPkgs.cardano-cli.components.exes.cardano-cli
+                  config.hsPkgs.cardano-node.components.exes.cardano-node
+                ]}"
+            '';
+          };
         })
       ];
 

--- a/flake.nix
+++ b/flake.nix
@@ -37,16 +37,10 @@
 
       haskellModules = bot-plutus-interface.haskellModules ++ [
         ({ config, pkgs, ... }:{
-          packages.plutip.components.tests.plutip-tests = {
-            pkgconfig = [[ pkgs.makeWrapper ]];
-            postInstall = with pkgs; ''
-              wrapProgram $out/bin/plutip-tests \
-                --prefix PATH : "${lib.makeBinPath [
-                  config.hsPkgs.cardano-cli.components.exes.cardano-cli
-                  config.hsPkgs.cardano-node.components.exes.cardano-node
-                ]}"
-            '';
-          };
+          packages.plutip.components.tests."plutip-tests".build-tools = [
+            config.hsPkgs.cardano-cli.components.exes.cardano-cli
+            config.hsPkgs.cardano-node.components.exes.cardano-node
+          ];
           packages.plutip.components.exes.local-cluster = {
             pkgconfig = [[ pkgs.makeWrapper ]];
             postInstall = with pkgs; ''


### PR DESCRIPTION
The need to manually ensure that the proper `cardano-cli` and `cardano-node` executables are available in the `PATH` variable is not a very _nixy_ approach. Threfore I've introduced `makeWrapper` to ensure that the proper executables are in the environment.

I did that for `local-cluster` and `plutip-tests` both run successfully now. Please let me know what other executables require to have `cardano-cli` and `cardano-node` in the `PATH`

Editing this flake I also found it very difficult to edit the `cabalProject` function parameters like `modules`. Wrapping `cabalProject` inside another function is a huge anti-pattern in my opinion. As soon as there are more options required you will basically find yourself writing an additional parameter for `nix/haskell.nix` just to propagate it to `cabalProject`