### PR TITLE
Misha/issue 84 values assert

### DIFF
--- a/plutip.cabal
+++ b/plutip.cabal
@@ -182,6 +182,7 @@ test-suite plutip-tests
     Spec.Test.Plutip.BotPlutusInterface
     Spec.TestContract.AlwaysFail
     Spec.TestContract.LockSpendMint
+    Spec.TestContract.SimpleContracts
     Spec.TestContract.ValidateTimeRange
 
   default-extensions:

--- a/src/Test/Plutip/Contract.hs
+++ b/src/Test/Plutip/Contract.hs
@@ -305,16 +305,19 @@ withContractAs walletIdx toContract = do
       it is important to preserve this order for Values check with `assertValues`
       as there is no other mechanism atm to match `TestWallet` with collected `Value`
       -}
-
       collectValuesPkhs = fmap ledgerPaymentPkh wallets'
+
+      -- wallelt `PaymentPubKeyHash`es that will be available in
+      -- `withContract` and `withContractAs`
+      otherWalletsPkhs = fmap ledgerPaymentPkh otherWallets
       contract =
         wrapContract
           collectValuesPkhs
-          (toContract $ map ledgerPaymentPkh otherWallets)
+          (toContract otherWalletsPkhs)
   liftIO $ runContract cEnv ownWallet contract
   where
     separateWallets i xss
-      | (xs, y : ys) <- NonEmpty.splitAt i xss = (y, xs ++ ys)
+      | (xs, y : ys) <- NonEmpty.splitAt i xss = (y, xs <> ys)
       | otherwise = error $ "Should fail: bad wallet index for own wallet: " <> show i
 
 -- | Wrap test contracts to wait for transaction submission and

--- a/src/Test/Plutip/Contract.hs
+++ b/src/Test/Plutip/Contract.hs
@@ -134,7 +134,7 @@ import Control.Monad (void)
 import Control.Monad.Reader (MonadIO (liftIO), MonadReader (ask), ReaderT, runReaderT)
 import Data.Bool (bool)
 import Data.Kind (Type)
-import Data.List.NonEmpty (NonEmpty ((:|)))
+import Data.List.NonEmpty (NonEmpty)
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.Maybe (isJust)
 import Data.Row (Row)
@@ -295,13 +295,27 @@ withContractAs ::
   TestRunner w e a
 withContractAs walletIdx toContract = do
   (cEnv, wallets') <- ask
-  let wallets@(ownWallet :| otherWallets) = reorder walletIdx wallets'
-  let contract = wrapContract wallets (toContract (map ledgerPaymentPkh otherWallets))
+  let -- pick wallet for Contract's "own PKH", other wallets PKHs will be provided
+      -- to the user in `withContractAs`
+      (ownWallet, otherWallets) = separateWallets walletIdx wallets'
+
+      {- these are `PaymentPubKeyHash`es of all wallets used in test case
+      they stay in list is same order as `TestWallets` defined in test case
+      so collected Values will be in same order as well
+      it is important to preserve this order for Values check with `assertValues`
+      as there is no other mechanism atm to match `TestWallet` with collected `Value`
+      -}
+
+      collectValuesPkhs = fmap ledgerPaymentPkh wallets'
+      contract =
+        wrapContract
+          collectValuesPkhs
+          (toContract $ map ledgerPaymentPkh otherWallets)
   liftIO $ runContract cEnv ownWallet contract
   where
-    reorder i xss = case NonEmpty.splitAt i xss of
-      (xs, y : ys) -> y :| xs ++ ys
-      _ -> error $ "Should fail: bad wallet index for own wallet: " <> show i
+    separateWallets i xss
+      | (xs, y : ys) <- NonEmpty.splitAt i xss = (y, xs ++ ys)
+      | otherwise = error $ "Should fail: bad wallet index for own wallet: " <> show i
 
 -- | Wrap test contracts to wait for transaction submission and
 -- to get the utxo amount at test wallets and wait for transaction.
@@ -310,14 +324,13 @@ withContractAs walletIdx toContract = do
 wrapContract ::
   forall (w :: Type) (s :: Row Type) (e :: Type) (a :: Type).
   TestContractConstraints w e a =>
-  NonEmpty BpiWallet ->
+  NonEmpty PaymentPubKeyHash ->
   Contract w s e a ->
   Contract w s e (a, NonEmpty Value)
-wrapContract bpiWallets contract = do
+wrapContract collectValuesPkhs contract = do
   res <- contract
   void $ waitNSlots 1
-  let walletPkhs = fmap ledgerPaymentPkh bpiWallets
-  values <- traverse (valueAt . (`pubKeyHashAddress` Nothing)) walletPkhs
+  values <- traverse (valueAt . (`pubKeyHashAddress` Nothing)) collectValuesPkhs
   pure (res, values)
 
 newtype StatsReport w e a = StatsReport (IO (ExecutionResult w e (a, NonEmpty Value)))

--- a/test/Spec/Integration.hs
+++ b/test/Spec/Integration.hs
@@ -4,14 +4,11 @@ import BotPlutusInterface.Types (LogContext (ContractLog), LogLevel (Debug))
 import Control.Exception (ErrorCall, Exception (fromException))
 import Control.Monad (void)
 import Data.Default (Default (def))
-
+import Data.List.NonEmpty (NonEmpty)
 import Data.Map qualified as Map
 import Data.Maybe (isJust)
 import Data.Text (Text, isInfixOf, pack)
-
 import Ledger.Constraints (MkTxError (OwnPubKeyMissing))
-
-import Data.List.NonEmpty (NonEmpty)
 import Plutus.Contract (
   ContractError (ConstraintResolutionContractError),
   waitNSlots,

--- a/test/Spec/Integration.hs
+++ b/test/Spec/Integration.hs
@@ -2,53 +2,52 @@ module Spec.Integration (test) where
 
 import BotPlutusInterface.Types (LogContext (ContractLog), LogLevel (Debug))
 import Control.Exception (ErrorCall, Exception (fromException))
-import Control.Lens ((^.))
 import Control.Monad (void)
 import Data.Default (Default (def))
-import Data.Map (Map)
+
 import Data.Map qualified as Map
 import Data.Maybe (isJust)
 import Data.Text (Text, isInfixOf, pack)
-import Ledger (
-  CardanoTx,
-  ChainIndexTxOut,
-  PaymentPubKeyHash,
-  TxOutRef,
-  Value,
-  ciTxOutValue,
-  pubKeyHashAddress,
- )
-import Ledger.Ada qualified as Ada
+
 import Ledger.Constraints (MkTxError (OwnPubKeyMissing))
-import Ledger.Constraints qualified as Constraints
+
+import Data.List.NonEmpty (NonEmpty)
 import Plutus.Contract (
-  Contract,
   ContractError (ConstraintResolutionContractError),
-  submitTx,
-  utxosAt,
+  waitNSlots,
  )
 import Plutus.Contract qualified as Contract
-import Plutus.PAB.Effects.Contract.Builtin (EmptySchema)
 import Plutus.V1.Ledger.Ada (lovelaceValueOf)
 import Spec.TestContract.AlwaysFail (lockThenFailToSpend)
 import Spec.TestContract.LockSpendMint (lockThenSpend)
+import Spec.TestContract.SimpleContracts (
+  getUtxos,
+  getUtxosThrowsErr,
+  getUtxosThrowsEx,
+  ownValue,
+  ownValueToState,
+  payTo,
+ )
 import Spec.TestContract.ValidateTimeRange (failingTimeContract, successTimeContract)
 import Test.Plutip.Contract (
+  TestWallets,
   ValueOrdering (VLt),
   assertExecution,
   assertExecutionWith,
   initAda,
   initAndAssertAda,
   initAndAssertAdaWith,
+  initAndAssertLovelace,
   initLovelace,
   withContract,
   withContractAs,
  )
 import Test.Plutip.Internal.Types (
+  ClusterEnv,
   FailureReason (CaughtException),
   isException,
  )
-import Test.Plutip.LocalCluster (withConfiguredCluster)
+import Test.Plutip.LocalCluster (BpiWallet, withConfiguredCluster)
 import Test.Plutip.Options (TraceOption (ShowBudgets, ShowTraceButOnlyContext))
 import Test.Plutip.Predicate (
   assertOverallBudget,
@@ -74,162 +73,204 @@ test =
   withConfiguredCluster
     def
     "Basic integration: launch, add wallet, tx from wallet to wallet"
-    [ -- Basic Succeed or Failed tests
-      assertExecution
-        "Contract 1"
-        (initAda (100 : replicate 10 7))
-        (withContract $ const getUtxos)
-        [ shouldSucceed
-        , Predicate.not shouldFail
-        ]
-    , assertExecution
-        "Contract 2"
-        (initAda [100])
-        (withContract $ const getUtxosThrowsErr)
-        [ shouldFail
-        , Predicate.not shouldSucceed
-        ]
-    , assertExecutionWith
-        [ShowTraceButOnlyContext ContractLog Debug]
-        "Contract 3"
-        (initAda [100])
-        (withContract $ const $ Contract.logInfo @Text "Some contract log with Info level." >> getUtxosThrowsEx)
-        [ shouldFail
-        , Predicate.not shouldSucceed
-        ]
-    , assertExecution
-        "Pay negative amount"
-        (initAda [100])
-        (withContract $ \[pkh1] -> payTo pkh1 (-10_000_000))
-        [shouldFail]
-    , -- Tests with wallet's Value assertions
-      assertExecution
-        "Pay from wallet to wallet"
-        (initAda [100] <> initAndAssertAda [100, 13] 123)
-        (withContract $ \[pkh1] -> payTo pkh1 10_000_000)
-        [shouldSucceed]
-    , assertExecution
-        "Two contracts one after another"
-        ( initAndAssertAdaWith [100] VLt 100 -- own wallet (index 0 in wallets list)
-            <> initAndAssertAdaWith [100] VLt 100 -- wallet with index 1 in wallets list
-        )
-        ( do
-            void $ -- run something prior to the contract which result will be checked
-              withContract $
+    $ [
+        -- Basic Succeed or Failed tests
+        assertExecution
+          "Contract 1"
+          (initAda (100 : replicate 10 7))
+          (withContract $ const getUtxos)
+          [ shouldSucceed
+          , Predicate.not shouldFail
+          ]
+      , assertExecution
+          "Contract 2"
+          (initAda [100])
+          (withContract $ const getUtxosThrowsErr)
+          [ shouldFail
+          , Predicate.not shouldSucceed
+          ]
+      , assertExecutionWith
+          [ShowTraceButOnlyContext ContractLog Debug]
+          "Contract 3"
+          (initAda [100])
+          (withContract $ const $ Contract.logInfo @Text "Some contract log with Info level." >> getUtxosThrowsEx)
+          [ shouldFail
+          , Predicate.not shouldSucceed
+          ]
+      , assertExecution
+          "Pay negative amount"
+          (initAda [100])
+          (withContract $ \[pkh1] -> payTo pkh1 (-10_000_000))
+          [shouldFail]
+      , -- Tests with wallet's Value assertions
+        assertExecution
+          "Pay from wallet to wallet"
+          (initAda [100] <> initAndAssertAda [100, 13] 123)
+          (withContract $ \[pkh1] -> payTo pkh1 10_000_000)
+          [shouldSucceed]
+      , assertExecution
+          "Two contracts one after another"
+          ( initAndAssertAdaWith [100] VLt 100 -- own wallet (index 0 in wallets list)
+              <> initAndAssertAdaWith [100] VLt 100 -- wallet with index 1 in wallets list
+          )
+          ( do
+              void $ -- run something prior to the contract which result will be checked
+                withContract $
+                  \[pkh1] -> payTo pkh1 10_000_000
+              withContractAs 1 $ -- run contract which result will be checked
                 \[pkh1] -> payTo pkh1 10_000_000
-            withContractAs 1 $ -- run contract which result will be checked
-              \[pkh1] -> payTo pkh1 10_000_000
-        )
-        [shouldSucceed]
-    , -- Tests with assertions on Contract return value
-      assertExecution
-        "Initiate wallet and get UTxOs"
-        (initAda [100])
-        (withContract $ const getUtxos)
-        [ yieldSatisfies "Returns single UTxO" ((== 1) . Map.size)
-        ]
-    , let initFunds = 10_000_000
-       in assertExecution
-            "Should yield own initial Ada"
-            (initLovelace [toEnum initFunds])
-            (withContract $ const ownValue)
-            [ shouldYield (lovelaceValueOf $ toEnum initFunds)
-            ]
-    , -- Tests with assertions on state
-      let initFunds = 10_000_000
-       in assertExecution
-            "Puts own UTxOs Value to state"
-            (initLovelace [toEnum initFunds])
-            (withContract $ const ownValueToState)
-            [ stateIs [lovelaceValueOf $ toEnum initFunds]
-            , Predicate.not $ stateSatisfies "length > 1" ((> 1) . length)
-            ]
-    , -- Tests with assertions on failure
-      let expectedErr = ConstraintResolutionContractError OwnPubKeyMissing
-          isResolutionError = \case
-            ConstraintResolutionContractError _ -> True
-            _ -> False
-       in assertExecution
-            ("Contract which throws `" <> show expectedErr <> "`")
-            (initAda [100])
-            (withContract $ const getUtxosThrowsErr)
-            [ shouldThrow expectedErr
-            , errorSatisfies "Throws resolution error" isResolutionError
-            , Predicate.not $ failReasonSatisfies "Throws exception" isException
-            ]
-    , let checkException = \case
-            CaughtException e -> isJust @ErrorCall (fromException e)
-            _ -> False
-       in assertExecution
-            "Contract which throws exception"
-            (initAda [100])
-            (withContract $ const getUtxosThrowsEx)
-            [ shouldFail
-            , Predicate.not shouldSucceed
-            , failReasonSatisfies "Throws ErrorCall" checkException
-            ]
-    , -- tests with assertions on execution budget
-      assertExecutionWith
-        [ShowBudgets] -- this influences displaying the budgets only and is not necessary for budget assertions
-        "Lock then spend contract"
-        (initAda (replicate 3 300))
-        (withContract $ const lockThenSpend)
-        [ shouldSucceed
-        , budgetsFitUnder
-            (scriptLimit 426019962 1082502)
-            (policyLimit 428879716 1098524)
-        , assertOverallBudget
-            "Assert CPU == 1156006922 and MEM == 2860068"
-            (== 1156006922)
-            (== 2860068)
-        , overallBudgetFits 1156006922 2860068
-        ]
-    , -- regression tests for time <-> slot converions
-      assertExecution
-        "Fails because outside validity interval"
-        (initAda [100])
-        (withContract $ const failingTimeContract)
-        [shouldFail]
-    , assertExecution
-        "Passes validation with exact time range checks"
-        (initAda [100])
-        (withContract $ const successTimeContract)
-        [shouldSucceed]
-    , -- always fail validation test
-      let errCheck e = "I always fail" `isInfixOf` pack (show e)
-       in assertExecution
-            "Always fails to validate"
-            (initAda [100])
-            (withContract $ const lockThenFailToSpend)
-            [ shouldFail
-            , errorSatisfies "Fail validation with 'I always fail'" errCheck
-            ]
-    ]
+          )
+          [shouldSucceed]
+      , -- Tests with assertions on Contract return value
+        assertExecution
+          "Initiate wallet and get UTxOs"
+          (initAda [100])
+          (withContract $ const getUtxos)
+          [ yieldSatisfies "Returns single UTxO" ((== 1) . Map.size)
+          ]
+      , let initFunds = 10_000_000
+         in assertExecution
+              "Should yield own initial Ada"
+              (initLovelace [toEnum initFunds])
+              (withContract $ const ownValue)
+              [ shouldYield (lovelaceValueOf $ toEnum initFunds)
+              ]
+      , -- Tests with assertions on state
+        let initFunds = 10_000_000
+         in assertExecution
+              "Puts own UTxOs Value to state"
+              (initLovelace [toEnum initFunds])
+              (withContract $ const ownValueToState)
+              [ stateIs [lovelaceValueOf $ toEnum initFunds]
+              , Predicate.not $ stateSatisfies "length > 1" ((> 1) . length)
+              ]
+      , -- Tests with assertions on failure
+        let expectedErr = ConstraintResolutionContractError OwnPubKeyMissing
+            isResolutionError = \case
+              ConstraintResolutionContractError _ -> True
+              _ -> False
+         in assertExecution
+              ("Contract which throws `" <> show expectedErr <> "`")
+              (initAda [100])
+              (withContract $ const getUtxosThrowsErr)
+              [ shouldThrow expectedErr
+              , errorSatisfies "Throws resolution error" isResolutionError
+              , Predicate.not $ failReasonSatisfies "Throws exception" isException
+              ]
+      , let checkException = \case
+              CaughtException e -> isJust @ErrorCall (fromException e)
+              _ -> False
+         in assertExecution
+              "Contract which throws exception"
+              (initAda [100])
+              (withContract $ const getUtxosThrowsEx)
+              [ shouldFail
+              , Predicate.not shouldSucceed
+              , failReasonSatisfies "Throws ErrorCall" checkException
+              ]
+      , -- tests with assertions on execution budget
+        assertExecutionWith
+          [ShowBudgets] -- this influences displaying the budgets only and is not necessary for budget assertions
+          "Lock then spend contract"
+          (initAda (replicate 3 300))
+          (withContract $ const lockThenSpend)
+          [ shouldSucceed
+          , budgetsFitUnder
+              (scriptLimit 426019962 1082502)
+              (policyLimit 428879716 1098524)
+          , assertOverallBudget
+              "Assert CPU == 1156006922 and MEM == 2860068"
+              (== 1156006922)
+              (== 2860068)
+          , overallBudgetFits 1156006922 2860068
+          ]
+      , -- regression tests for time <-> slot conversions
+        assertExecution
+          "Fails because outside validity interval"
+          (initAda [100])
+          (withContract $ const failingTimeContract)
+          [shouldFail]
+      , assertExecution
+          "Passes validation with exact time range checks"
+          (initAda [100])
+          (withContract $ const successTimeContract)
+          [shouldSucceed]
+      , -- always fail validation test
+        let errCheck e = "I always fail" `isInfixOf` pack (show e)
+         in assertExecution
+              "Always fails to validate"
+              (initAda [100])
+              (withContract $ const lockThenFailToSpend)
+              [ shouldFail
+              , errorSatisfies "Fail validation with 'I always fail'" errCheck
+              ]
+      ]
+      ++ testValueAssertionsOrderCorrectness
 
-getUtxos :: Contract [Value] EmptySchema Text (Map TxOutRef ChainIndexTxOut)
-getUtxos = do
-  pkh <- Contract.ownPaymentPubKeyHash
-  utxosAt $ pubKeyHashAddress pkh Nothing
+-- Tests for https://github.com/mlabs-haskell/plutip/issues/84
+testValueAssertionsOrderCorrectness ::
+  [(TestWallets, IO (ClusterEnv, NonEmpty BpiWallet) -> TestTree)]
+testValueAssertionsOrderCorrectness =
+  [ -- withContract case
+    let wallet0 = 100_000_000
+        wallet1 = 200_000_000
+        wallet2 = 300_000_000
 
-getUtxosThrowsErr :: Contract () EmptySchema ContractError (Map TxOutRef ChainIndexTxOut)
-getUtxosThrowsErr =
-  Contract.throwError $ ConstraintResolutionContractError OwnPubKeyMissing
+        payFee = 146200 -- taken from trace
+        payTo1Amt = 22_000_000
+        payTo2Amt = 33_000_000
+        wallet1After = wallet1 + payTo1Amt
+        wallet2After = wallet2 + payTo2Amt
+        wallet0After = wallet0 - payTo1Amt - payFee - payTo2Amt - payFee
+     in assertExecution
+          "Values asserted in correct order with withContract"
+          ( initAndAssertLovelace [wallet0] wallet0After
+              <> initAndAssertLovelace [wallet1] wallet1After
+              <> initAndAssertLovelace [wallet2] wallet2After
+          )
+          ( do
+              withContract $ \[w1pkh, w2pkh] -> do
+                _ <- payTo w1pkh (toInteger payTo1Amt)
+                _ <- waitNSlots 2
+                payTo w2pkh (toInteger payTo2Amt)
+          )
+          [shouldSucceed]
+  , -- withContractAs case
+    let wallet0 = 100_000_000
+        wallet1 = 200_000_000
+        wallet2 = 300_000_000
 
-getUtxosThrowsEx :: Contract () EmptySchema Text (Map TxOutRef ChainIndexTxOut)
-getUtxosThrowsEx = error "This Exception was thrown intentionally in Contract.\n"
+        payFee = 146200 -- taken from trace
+        payTo0Amt = 11_000_000
+        payTo1Amt = 22_000_000
+        payTo2Amt = 33_000_000
 
-payTo :: PaymentPubKeyHash -> Integer -> Contract () EmptySchema Text CardanoTx
-payTo toPkh amt = do
-  submitTx (Constraints.mustPayToPubKey toPkh (Ada.lovelaceValueOf amt))
+        wallet0After = wallet0 + payTo0Amt
+        wallet2After =
+          wallet2 + payTo2Amt
+            - payTo1Amt
+            - payFee
+        wallet1After =
+          wallet1 + payTo1Amt
+            - payTo0Amt
+            - payFee
+            - payTo2Amt
+            - payFee
+     in assertExecution
+          "Values asserted in correct order with withContractAs"
+          ( initAndAssertLovelace [wallet0] wallet0After
+              <> initAndAssertLovelace [wallet1] wallet1After
+              <> initAndAssertLovelace [wallet2] wallet2After
+          )
+          ( do
+              void $
+                withContractAs 1 $ \[w0pkh, w2pkh] -> do
+                  _ <- payTo w0pkh (toInteger payTo0Amt)
+                  _ <- waitNSlots 2
+                  payTo w2pkh (toInteger payTo2Amt)
 
-ownValue :: Contract [Value] EmptySchema Text Value
-ownValue = foldMap (^. ciTxOutValue) <$> getUtxos
-
--- this Contract fails, but state should change in expected way
-ownValueToState :: Contract [Value] EmptySchema Text ()
-ownValueToState = do
-  ownValue >>= Contract.tell . (: [])
-  void $ Contract.throwError "Intentional fail"
-  ownValue
-    >>= Contract.tell
-      . (: []) -- should not be in state
+              withContractAs 2 $ \[_, w1pkh] -> do
+                payTo w1pkh (toInteger payTo1Amt)
+          )
+          [shouldSucceed]
+  ]

--- a/test/Spec/TestContract/SimpleContracts.hs
+++ b/test/Spec/TestContract/SimpleContracts.hs
@@ -48,7 +48,7 @@ getUtxosThrowsEx :: Contract () EmptySchema Text (Map TxOutRef ChainIndexTxOut)
 getUtxosThrowsEx = error "This Exception was thrown intentionally in Contract.\n"
 
 payTo :: PaymentPubKeyHash -> Integer -> Contract () EmptySchema Text CardanoTx
-payTo toPkh amt = do
+payTo toPkh amt =
   submitTx (Constraints.mustPayToPubKey toPkh (Ada.lovelaceValueOf amt))
 
 ownValue :: Contract [Value] EmptySchema Text Value

--- a/test/Spec/TestContract/SimpleContracts.hs
+++ b/test/Spec/TestContract/SimpleContracts.hs
@@ -1,0 +1,64 @@
+module Spec.TestContract.SimpleContracts (
+  getUtxos,
+  getUtxosThrowsErr,
+  getUtxosThrowsEx,
+  payTo,
+  ownValue,
+  ownValueToState,
+) where
+
+import Plutus.Contract (
+  Contract,
+  ContractError (ConstraintResolutionContractError),
+  submitTx,
+  utxosAt,
+ )
+import Plutus.Contract qualified as Contract
+
+import Ledger (
+  CardanoTx,
+  ChainIndexTxOut,
+  PaymentPubKeyHash,
+  TxOutRef,
+  Value,
+  ciTxOutValue,
+  pubKeyHashAddress,
+ )
+
+import Data.Map (Map)
+import Ledger.Ada qualified as Ada
+
+import Control.Lens ((^.))
+import Control.Monad (void)
+import Data.Text (Text)
+import Ledger.Constraints (MkTxError (OwnPubKeyMissing))
+import Ledger.Constraints qualified as Constraints
+import Plutus.PAB.Effects.Contract.Builtin (EmptySchema)
+
+getUtxos :: Contract [Value] EmptySchema Text (Map TxOutRef ChainIndexTxOut)
+getUtxos = do
+  pkh <- Contract.ownPaymentPubKeyHash
+  utxosAt $ pubKeyHashAddress pkh Nothing
+
+getUtxosThrowsErr :: Contract () EmptySchema ContractError (Map TxOutRef ChainIndexTxOut)
+getUtxosThrowsErr =
+  Contract.throwError $ ConstraintResolutionContractError OwnPubKeyMissing
+
+getUtxosThrowsEx :: Contract () EmptySchema Text (Map TxOutRef ChainIndexTxOut)
+getUtxosThrowsEx = error "This Exception was thrown intentionally in Contract.\n"
+
+payTo :: PaymentPubKeyHash -> Integer -> Contract () EmptySchema Text CardanoTx
+payTo toPkh amt = do
+  submitTx (Constraints.mustPayToPubKey toPkh (Ada.lovelaceValueOf amt))
+
+ownValue :: Contract [Value] EmptySchema Text Value
+ownValue = foldMap (^. ciTxOutValue) <$> getUtxos
+
+-- this Contract fails, but state should change in expected way
+ownValueToState :: Contract [Value] EmptySchema Text ()
+ownValueToState = do
+  ownValue >>= Contract.tell . (: [])
+  void $ Contract.throwError "Intentional fail"
+  ownValue
+    >>= Contract.tell
+      . (: []) -- should not be in state


### PR DESCRIPTION
Resolves #84 

The problem was in wallets reordering when contract executed via  `withContractAs`. Wallets were getting reordered in that case to put wallet with user specified index to index `0` in list, then this ordering was used to collect `Value`'s from wallets after `Contract` finish. But initial ordering of `TestWallet`'s don't change, and that ordering defines the order of expected values for `assertValues`. So the order of collected `Values`s and order of  expected values didn't match in `assertValues` causing false assertion errors.