### PR TITLE
Move formatting check to `checks`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -145,7 +145,5 @@
               mkdir $out
             '';
         });
-
-      herculesCI.ciSystems = [ "x86_64-linux" ];
     };
 }


### PR DESCRIPTION
So it will be built by default by Hydra, and will still be included with `nix build .#check.<SYSTEM>`