### PR TITLE
Add arguments to `local-cluster` command.

### DIFF
--- a/local-cluster/Main.hs
+++ b/local-cluster/Main.hs
@@ -2,11 +2,15 @@
 
 module Main (main) where
 
-import Control.Monad (void)
+import Control.Applicative (optional, (<**>))
+import Control.Monad (void, replicateM, forM_)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Reader (ReaderT (ReaderT))
 import Data.Default (def)
-import Test.Plutip.Internal.BotPlutusInterface.Wallet (walletPkh)
+import Options.Applicative qualified as Options
+import Options.Applicative (Parser, info, sample, helper)
+import Test.Plutip.Config qualified as Config
+import Test.Plutip.Internal.BotPlutusInterface.Wallet (walletPkh, addSomeWalletDir)
 import Test.Plutip.Internal.Types (nodeSocket)
 import Test.Plutip.LocalCluster (
   addSomeWallet,
@@ -18,13 +22,16 @@ import Test.Plutip.LocalCluster (
 
 main :: IO ()
 main = do
+  args <- Options.execParser (info (sample <**> helper) pClusterConfig)
   (st, _) <- startCluster def $ do
-    w <- addSomeWallet [toAda 10000]
+    let nWall = numWallets args
+        wPath = dirWallets args
+    ws <- replicateM (max 1 nWall) $ addSomeWalletDir [toAda 10000] wPath
     waitSeconds 2 -- let wallet Tx finish, it can take more time with bigger slot length
     separate
-    liftIO $ do
-      putStrLn $ "Wallet PKH: " ++ show (walletPkh w)
-      putStrLn $ "Wallet mainnet address: " ++ show (mkMainnetAddress w)
+    forM_ (zip ws [1..]) $ \(w,n) -> liftIO $ do
+      putStrLn $ "Wallet " ++ show n ++ " PKH: " ++ show (walletPkh w)
+      putStrLn $ "Wallet " ++ show n ++ " mainnet address: " ++ show (mkMainnetAddress w)
     prtNodeRelatedInfo
     separate
 
@@ -40,3 +47,32 @@ main = do
     separate = liftIO $ putStrLn "\n------------\n"
 
     toAda = (* 1_000_000)
+
+
+pnumWallets :: Parser Int
+pnumWallets = Options.option Options.auto
+  (  Options.long "num-wallets"
+  <> Options.long "wallets"
+  <> Options.short 'n'
+  <> Options.metavar "NUM_WALLETS"
+  <> Options.value 1
+  )
+
+pdirWallets :: Parser (Maybe FilePath)
+pdirWallets = optional $ Options.strOption
+  (  Options.long "wallets-dir"
+  <> Options.long "wallet-dir"
+  <> Options.short 'd'
+  <> Options.metavar "FILEPATH"
+  )
+
+pClusterConfig :: Parser CWalletConfig
+pClusterConfig = CWalletConfig <$> pnumWallets <*> pdirWallets
+
+-- | Basic info about the cluster, to
+-- be used by the command-line
+data CWalletConfig = CWalletConfig
+  { numWallets :: Int
+  , dirWallets :: Maybe FilePath
+  } deriving stock (Show, Eq)
+

--- a/local-cluster/Main.hs
+++ b/local-cluster/Main.hs
@@ -11,7 +11,6 @@ import Control.Monad.Reader (ReaderT (ReaderT))
 import Data.Default (def)
 import Options.Applicative qualified as Options
 import Options.Applicative (Parser, info, helper)
-import Test.Plutip.Config qualified as Config
 import Test.Plutip.Internal.BotPlutusInterface.Wallet (walletPkh, addSomeWalletDir)
 import Test.Plutip.Internal.Types (nodeSocket)
 import Test.Plutip.LocalCluster (
@@ -27,7 +26,7 @@ main = do
   (st, _) <- startCluster def $ do
     let nWall = numWallets args
         wPath = dirWallets args
-        adaAmt = (toAda $ fromInteger $ abs $ adaAmount args) + (fromInteger $ abs $ lvlAmount args)
+        adaAmt = toAda (fromInteger $ abs $ adaAmount args) + fromInteger (abs $ lvlAmount args)
         nUtxos = numUtxos args
     ws <- replicateM (max 0 nWall) $ addSomeWalletDir (replicate nUtxos adaAmt) wPath
     waitSeconds 2 -- let wallet Tx finish, it can take more time with bigger slot length
@@ -94,10 +93,10 @@ pnumUtxos = Options.option Options.auto
   )
 
 pClusterConfig :: Parser CWalletConfig
-pClusterConfig = CWalletConfig 
-  <$> pnumWallets 
-  <*> pdirWallets 
-  <*> padaAmount 
+pClusterConfig = CWalletConfig
+  <$> pnumWallets
+  <*> pdirWallets
+  <*> padaAmount
   <*> plvlAmount
   <*> pnumUtxos
 

--- a/local-cluster/Main.hs
+++ b/local-cluster/Main.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE DerivingStrategies #-}
 
 module Main (main) where
 
@@ -8,7 +10,7 @@ import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Reader (ReaderT (ReaderT))
 import Data.Default (def)
 import Options.Applicative qualified as Options
-import Options.Applicative (Parser, info, sample, helper)
+import Options.Applicative (Parser, info, helper)
 import Test.Plutip.Config qualified as Config
 import Test.Plutip.Internal.BotPlutusInterface.Wallet (walletPkh, addSomeWalletDir)
 import Test.Plutip.Internal.Types (nodeSocket)
@@ -22,14 +24,14 @@ import Test.Plutip.LocalCluster (
 
 main :: IO ()
 main = do
-  args <- Options.execParser (info (sample <**> helper) pClusterConfig)
+  args <- Options.execParser (info (pClusterConfig <**> helper) mempty)
   (st, _) <- startCluster def $ do
     let nWall = numWallets args
         wPath = dirWallets args
     ws <- replicateM (max 1 nWall) $ addSomeWalletDir [toAda 10000] wPath
     waitSeconds 2 -- let wallet Tx finish, it can take more time with bigger slot length
     separate
-    forM_ (zip ws [1..]) $ \(w,n) -> liftIO $ do
+    forM_ (zip ws [(1 :: Int)..]) $ \(w,n) -> liftIO $ do
       putStrLn $ "Wallet " ++ show n ++ " PKH: " ++ show (walletPkh w)
       putStrLn $ "Wallet " ++ show n ++ " mainnet address: " ++ show (mkMainnetAddress w)
     prtNodeRelatedInfo

--- a/local-cluster/README.md
+++ b/local-cluster/README.md
@@ -6,7 +6,7 @@ As long as the cluster is not stopped, the relay node can be used for arbitrary 
 
 The node socket path can be obtained from console output.
 
-Note that when wallet is added with `addSomeWallet` it is recommended to wait some time (1 or 2 seconds) with `waitSeconds` while funding transaction is sent and confirmed.
+The `Main.hs` module can also serve as an example of how to make your own executable for starting local cluster with funded wallets. Note that when wallet is added with `addSomeWallet` it is recommended to wait some time (1 or 2 seconds) with `waitSeconds` while funding transaction is sent and confirmed.
 
 ## Usage 
 
@@ -16,7 +16,9 @@ The local cluster can be started by running
 cabal run local-cluster -- <arguments>
 ```
 
-The available arguments are as follows:
+When you see in terminal message like "`Cluster is running. Press Enter to stop.`" it means that local cluster started successfully and all desired wallets created and funded.
+
+### Available arguments
 
 ```
 --wallets NUM
@@ -68,8 +70,4 @@ amount will be 5.000001 ADA instead of 4.999999 ADA.
 ```
 
 Create `NUM` UTxOs in each wallet created. Note that each UTxO created has the amount
-of ADA determined by the `--ada` and `--lovelace` arguments. 
-
-
-
-
+of ADA determined by the `--ada` and `--lovelace` arguments.

--- a/local-cluster/README.md
+++ b/local-cluster/README.md
@@ -1,9 +1,75 @@
 # Starting local cluster with chain-index
 
-This example shows how to start local cluster (BFT node + relay node) and add single wallet with some Ada on it's address.
+This example starts a local cluster (BFT node + relay node) and by default adds a single wallet with some Ada on it's address.
 
 As long as the cluster is not stopped, the relay node can be used for arbitrary actions that require network communication.
 
-Node socket path can be obtained from console output.
+The node socket path can be obtained from console output.
 
 Note that when wallet is added with `addSomeWallet` it is recommended to wait some time (1 or 2 seconds) with `waitSeconds` while funding transaction is sent and confirmed.
+
+## Usage 
+
+The local cluster can be started by running
+
+```
+cabal run local-cluster -- <arguments>
+```
+
+The available arguments are as follows:
+
+```
+--wallets NUM
+-n NUM
+```
+
+This creates `NUM` wallets and saves info about them into a default directory
+and also to a user-specified directory if the `--wallet-dir` argument is used.
+This defaults to 1 if not specified, and can be set to 0 if you do not wish to
+create any wallets.
+
+```
+--wallet-dir /path/
+-d /path/
+```
+
+If specified, this saves the wallet information to an extra directory specified by
+the user. This is useful if you wish to have wallet information easily accessible
+by other code.
+
+```
+--ada AMOUNT
+-a AMOUNT
+```
+
+This puts `AMOUNT` Ada into each UTxO in every wallet created. This defaults to
+10,000 ADA. If you wish to specify an additional amount in Lovelace, you can use
+the `--lovelace` argument below. Note that if you want to specify the amount to 
+create entirely in Lovelace, you'll have to use `-a0 --lovelace AMOUNT`.
+
+```
+--lovelace AMOUNT
+-l AMOUNT
+```
+
+This puts `AMOUNT` Lovelace into each UTxO in every wallet created, in addition to
+the amount specified by the `--ada` argument. Note that if you don't specify the
+amount of ADA to add, the total amount will be 10,000 ADA + `AMOUNT` lovelace.
+
+
+Note that for both `--ada` and `--lovelace`, the values' absolute values are taken
+and then added together to get the total amount to use for the UTxOs. Note that this
+means that if you use a command like `local-cluster --ada 5 --lovelace -1`, the final
+amount will be 5.000001 ADA instead of 4.999999 ADA.
+
+```
+--utxos NUM
+-u NUM
+```
+
+Create `NUM` UTxOs in each wallet created. Note that each UTxO created has the amount
+of ADA determined by the `--ada` and `--lovelace` arguments. 
+
+
+
+

--- a/plutip.cabal
+++ b/plutip.cabal
@@ -239,6 +239,7 @@ executable local-cluster
     , base
     , data-default
     , mtl
+    , optparse-applicative
     , plutip
 
   ghc-options:   -Wall -threaded -rtsopts

--- a/src/Test/Plutip/Internal/BotPlutusInterface/Wallet.hs
+++ b/src/Test/Plutip/Internal/BotPlutusInterface/Wallet.hs
@@ -75,7 +75,7 @@ eitherAddSomeWalletDir :: MonadIO m => [Positive] -> Maybe FilePath -> ReaderT C
 eitherAddSomeWalletDir funds wallDir = do
   bpiWallet <- createWallet
   case wallDir of
-    Nothing      -> pure ()
+    Nothing -> pure ()
     (Just direc) -> void $ saveWalletDir bpiWallet direc
   saveWallet bpiWallet
     >>= \case
@@ -138,7 +138,6 @@ saveWalletDir (BpiWallet pkh _ sk) wallDir = do
       path = wallDir </> "signing-key-" ++ pkhStr <.> "skey"
   res <- liftIO $ CAPI.writeFileTextEnvelope path (Just "Payment Signing Key") sk
   return $ left (SignKeySaveError . show) res --todo: better error handling
-  
 
 -- | Make `AnyAddress` for mainnet
 cardanoMainnetAddress :: BpiWallet -> AddressAny

--- a/src/Test/Plutip/Internal/BotPlutusInterface/Wallet.hs
+++ b/src/Test/Plutip/Internal/BotPlutusInterface/Wallet.hs
@@ -51,23 +51,7 @@ During wallet addition `.skey` file with required name generated and saved
  Directory for files could be obtained with `Test.Plutip.BotPlutusInterface.Setup.keysDir`
 -}
 eitherAddSomeWallet :: MonadIO m => [Positive] -> ReaderT ClusterEnv m (Either BpiError BpiWallet)
-eitherAddSomeWallet funds = do
-  bpiWallet <- createWallet
-  saveWallet bpiWallet
-    >>= \case
-      Right _ -> sendFunds bpiWallet >> pure (Right bpiWallet)
-      Left err -> pure $ Left err
-  where
-    sendFunds wallet = do
-      cEnv <- ask
-      let fundAddress = mkMainnetAddress wallet
-          toAmt = Coin . fromIntegral
-      liftIO $
-        sendFaucetFundsTo
-          nullTracer -- todo: fix tracer to be not `nullTracer`
-          (nodeSocket cEnv)
-          (supportDir cEnv)
-          [(fundAddress, toAmt v) | v <- funds]
+eitherAddSomeWallet funds = eitherAddSomeWalletDir funds Nothing
 
 -- | The same as `eitherAddSomeWallet`, but also
 -- saves the key file to a separate directory.


### PR DESCRIPTION
This adds two basic arguments to the `local-cluster` command:

- `--wallets n`, which indicates the number of wallets to create.
- `--wallet-dir /path/`, which indicates an extra directory to save the `.skey` files to.

They can be tested by running `cabal run local-cluster -- <args>` while in the nix-shell.