### PR TITLE
Add working directory argument for local-cluster

### DIFF
--- a/local-cluster/Main.hs
+++ b/local-cluster/Main.hs
@@ -8,9 +8,12 @@ import Control.Applicative (optional, (<**>))
 import Control.Monad (void, replicateM, forM_)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Reader (ReaderT (ReaderT))
-import Data.Default (def)
 import Options.Applicative qualified as Options
 import Options.Applicative (Parser, info, helper)
+import Test.Plutip.Config (
+  WorkingDirectory (Temporary, Fixed),
+  PlutipConfig (PlutipConfig),
+ )
 import Test.Plutip.Internal.BotPlutusInterface.Wallet (walletPkh, addSomeWalletDir)
 import Test.Plutip.Internal.Types (nodeSocket)
 import Test.Plutip.LocalCluster (
@@ -23,7 +26,9 @@ import Test.Plutip.LocalCluster (
 main :: IO ()
 main = do
   args <- Options.execParser (info (pClusterConfig <**> helper) mempty)
-  (st, _) <- startCluster def $ do
+  let workingDir = maybe Temporary (flip Fixed False) (dirWorking args)
+      plutipConfig = PlutipConfig Nothing Nothing Nothing 1 workingDir []
+  (st, _) <- startCluster plutipConfig $ do
     let nWall = numWallets args
         wPath = dirWallets args
         adaAmt = toAda (fromInteger $ abs $ adaAmount args) + fromInteger (abs $ lvlAmount args)
@@ -92,6 +97,13 @@ pnumUtxos = Options.option Options.auto
   <> Options.value 1
   )
 
+pdirWorking :: Parser (Maybe FilePath)
+pdirWorking = optional $ Options.strOption
+  (  Options.long "working-dir"
+  <> Options.short 'w'
+  <> Options.metavar "FILEPATH"
+  )
+
 pClusterConfig :: Parser CWalletConfig
 pClusterConfig = CWalletConfig
   <$> pnumWallets
@@ -99,6 +111,7 @@ pClusterConfig = CWalletConfig
   <*> padaAmount
   <*> plvlAmount
   <*> pnumUtxos
+  <*> pdirWorking
 
 -- | Basic info about the cluster, to
 -- be used by the command-line
@@ -108,5 +121,6 @@ data CWalletConfig = CWalletConfig
   , adaAmount  :: Integer
   , lvlAmount  :: Integer
   , numUtxos :: Int
+  , dirWorking :: Maybe FilePath
   } deriving stock (Show, Eq)
 

--- a/local-cluster/Main.hs
+++ b/local-cluster/Main.hs
@@ -8,11 +8,12 @@ import Control.Applicative (optional, (<**>))
 import Control.Monad (void, replicateM, forM_)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Reader (ReaderT (ReaderT))
+import Data.Default (def)
 import Options.Applicative qualified as Options
 import Options.Applicative (Parser, info, helper)
 import Test.Plutip.Config (
   WorkingDirectory (Temporary, Fixed),
-  PlutipConfig (PlutipConfig),
+  PlutipConfig (clusterWorkingDir),
  )
 import Test.Plutip.Internal.BotPlutusInterface.Wallet (walletPkh, addSomeWalletDir)
 import Test.Plutip.Internal.Types (nodeSocket)
@@ -26,7 +27,7 @@ import Test.Plutip.LocalCluster (
 main :: IO ()
 main = do
   args <- Options.execParser (info (pClusterConfig <**> helper) mempty)
-  let workingDir = maybe Temporary (flip Fixed False) (dirWorking args)
+  let workingDir = maybe Temporary (flip Fixed False) (workDir args)
       plutipConfig = def {clusterWorkingDir = workingDir}
   (st, _) <- startCluster plutipConfig $ do
     let nWall = numWallets args
@@ -97,8 +98,8 @@ pnumUtxos = Options.option Options.auto
   <> Options.value 1
   )
 
-pdirWorking :: Parser (Maybe FilePath)
-pdirWorking = optional $ Options.strOption
+pWorkDir :: Parser (Maybe FilePath)
+pWorkDir = optional $ Options.strOption
   (  Options.long "working-dir"
   <> Options.short 'w'
   <> Options.metavar "FILEPATH"
@@ -111,7 +112,7 @@ pClusterConfig = CWalletConfig
   <*> padaAmount
   <*> plvlAmount
   <*> pnumUtxos
-  <*> pdirWorking
+  <*> pWorkDir
 
 -- | Basic info about the cluster, to
 -- be used by the command-line
@@ -121,6 +122,6 @@ data CWalletConfig = CWalletConfig
   , adaAmount  :: Integer
   , lvlAmount  :: Integer
   , numUtxos :: Int
-  , dirWorking :: Maybe FilePath
+  , workDir  :: Maybe FilePath
   } deriving stock (Show, Eq)
 

--- a/local-cluster/Main.hs
+++ b/local-cluster/Main.hs
@@ -27,7 +27,7 @@ main :: IO ()
 main = do
   args <- Options.execParser (info (pClusterConfig <**> helper) mempty)
   let workingDir = maybe Temporary (flip Fixed False) (dirWorking args)
-      plutipConfig = PlutipConfig Nothing Nothing Nothing 1 workingDir []
+      plutipConfig = def {clusterWorkingDir = workingDir}
   (st, _) <- startCluster plutipConfig $ do
     let nWall = numWallets args
         wPath = dirWallets args

--- a/local-cluster/README.md
+++ b/local-cluster/README.md
@@ -71,3 +71,14 @@ amount will be 5.000001 ADA instead of 4.999999 ADA.
 
 Create `NUM` UTxOs in each wallet created. Note that each UTxO created has the amount
 of ADA determined by the `--ada` and `--lovelace` arguments.
+
+```
+--working-dir /path/
+-w /path/
+```
+
+This determines where the node database, chain-index database, and bot-plutus-interface
+files will be stored for a running cluster. If specified, this will store cluster
+data in the provided path (can be relative or absolute), the files will be deleted
+on cluster shutdown by default. Otherwise, the cluster data is stored in a temporary
+directory and will be deleted on cluster shutdown.


### PR DESCRIPTION
Provides an option to store the data of a running local-cluster into a specified working directory.