### PR TITLE
args parsing fix

### DIFF
--- a/local-cluster/Main.hs
+++ b/local-cluster/Main.hs
@@ -25,6 +25,7 @@ import Test.Plutip.LocalCluster
     stopCluster,
     waitSeconds,
   )
+import GHC.Natural (Natural)
 
 main :: IO ()
 main = do
@@ -58,9 +59,9 @@ main = do
 
     totalAmount :: CWalletConfig -> Either String Positive
     totalAmount cwc =
-      case toAda (abs $ adaAmount cwc) + abs (lvlAmount cwc) of
+      case toAda (adaAmount cwc) + lvlAmount cwc of
         0 -> Left "One of --ada or --lovelace arguments should not be 0"
-        amt -> Right $ fromInteger amt
+        amt -> Right $ fromInteger . toInteger $ amt
 
     initWallets numWallets numUtxos amt dirWallets = do
       replicateM (max 0 numWallets) $
@@ -93,7 +94,7 @@ pdirWallets =
           <> Options.metavar "FILEPATH"
       )
 
-padaAmount :: Parser Integer
+padaAmount :: Parser Natural
 padaAmount =
   Options.option
     Options.auto
@@ -103,7 +104,7 @@ padaAmount =
         <> Options.value 10_000
     )
 
-plvlAmount :: Parser Integer
+plvlAmount :: Parser Natural
 plvlAmount =
   Options.option
     Options.auto
@@ -147,8 +148,8 @@ pClusterConfig =
 data CWalletConfig = CWalletConfig
   { numWallets :: Int,
     dirWallets :: Maybe FilePath,
-    adaAmount :: Integer,
-    lvlAmount :: Integer,
+    adaAmount :: Natural,
+    lvlAmount :: Natural,
     numUtxos :: Int,
     workDir :: Maybe FilePath
   }

--- a/local-cluster/Main.hs
+++ b/local-cluster/Main.hs
@@ -1,127 +1,155 @@
-{-# LANGUAGE NumericUnderscores #-}
-{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE NumericUnderscores #-}
 
 module Main (main) where
 
 import Control.Applicative (optional, (<**>))
-import Control.Monad (void, replicateM, forM_)
+import Control.Monad (forM_, replicateM, void)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Reader (ReaderT (ReaderT))
 import Data.Default (def)
+import Numeric.Positive (Positive)
+import Options.Applicative (Parser, helper, info)
 import Options.Applicative qualified as Options
-import Options.Applicative (Parser, info, helper)
-import Test.Plutip.Config (
-  WorkingDirectory (Temporary, Fixed),
-  PlutipConfig (clusterWorkingDir),
- )
-import Test.Plutip.Internal.BotPlutusInterface.Wallet (walletPkh, addSomeWalletDir)
+import Test.Plutip.Config
+  ( PlutipConfig (clusterWorkingDir),
+    WorkingDirectory (Fixed, Temporary),
+  )
+import Test.Plutip.Internal.BotPlutusInterface.Wallet (addSomeWalletDir, walletPkh)
 import Test.Plutip.Internal.Types (nodeSocket)
-import Test.Plutip.LocalCluster (
-  mkMainnetAddress,
-  startCluster,
-  stopCluster,
-  waitSeconds,
- )
+import Test.Plutip.LocalCluster
+  ( mkMainnetAddress,
+    startCluster,
+    stopCluster,
+    waitSeconds,
+  )
 
 main :: IO ()
 main = do
-  args <- Options.execParser (info (pClusterConfig <**> helper) mempty)
-  let workingDir = maybe Temporary (flip Fixed False) (workDir args)
-      plutipConfig = def {clusterWorkingDir = workingDir}
-  (st, _) <- startCluster plutipConfig $ do
-    let nWall = numWallets args
-        wPath = dirWallets args
-        adaAmt = toAda (fromInteger $ abs $ adaAmount args) + fromInteger (abs $ lvlAmount args)
-        nUtxos = numUtxos args
-    ws <- replicateM (max 0 nWall) $ addSomeWalletDir (replicate nUtxos adaAmt) wPath
-    waitSeconds 2 -- let wallet Tx finish, it can take more time with bigger slot length
-    separate
-    forM_ (zip ws [(1 :: Int)..]) $ \(w,n) -> liftIO $ do
-      putStrLn $ "Wallet " ++ show n ++ " PKH: " ++ show (walletPkh w)
-      putStrLn $ "Wallet " ++ show n ++ " mainnet address: " ++ show (mkMainnetAddress w)
-    prtNodeRelatedInfo
-    separate
+  config <- Options.execParser (info (pClusterConfig <**> helper) mempty)
+  case totalAmount config of
+    Left e -> error e
+    Right amt -> do
+      let CWalletConfig {numWallets, dirWallets, numUtxos, workDir} = config
+          workingDir = maybe Temporary (`Fixed` False) workDir
+          plutipConfig = def {clusterWorkingDir = workingDir}
 
-  putStrLn "Cluster is running. Press Enter to stop."
-    >> void getLine
-  putStrLn "Stopping cluster"
+      (st, _) <- startCluster plutipConfig $ do
+        ws <- initWallets numWallets numUtxos amt dirWallets
+        waitSeconds 2 -- let wallet Tx finish, it can take more time with bigger slot length
+        
+        separate
+        liftIO $ forM_ (zip ws [(1 :: Int) ..]) printWallet
+        printNodeRelatedInfo
+        separate
 
-  stopCluster st
+      putStrLn "Cluster is running. Press Enter to stop."
+        >> void getLine
+      putStrLn "Stopping cluster"
+
+      stopCluster st
   where
-    prtNodeRelatedInfo = ReaderT $ \cEnv -> do
+    printNodeRelatedInfo = ReaderT $ \cEnv -> do
       putStrLn $ "Node socket: " <> show (nodeSocket cEnv)
 
     separate = liftIO $ putStrLn "\n------------\n"
 
+    totalAmount :: CWalletConfig -> Either String Positive
+    totalAmount cwc =
+      case toAda (adaAmount cwc) + lvlAmount cwc of
+        0 -> Left "One of --ada or --lovelace arguments should not be 0"
+        amt -> Right $ fromInteger amt
+
+    initWallets numWallets numUtxos amt dirWallets = do
+      replicateM (max 0 numWallets) $
+        addSomeWalletDir (replicate numUtxos amt) dirWallets
+
+    printWallet (w, n) = do
+      putStrLn $ "Wallet " ++ show n ++ " PKH: " ++ show (walletPkh w)
+      putStrLn $ "Wallet " ++ show n ++ " mainnet address: " ++ show (mkMainnetAddress w)
+
     toAda = (* 1_000_000)
 
-
 pnumWallets :: Parser Int
-pnumWallets = Options.option Options.auto
-  (  Options.long "num-wallets"
-  <> Options.long "wallets"
-  <> Options.short 'n'
-  <> Options.metavar "NUM_WALLETS"
-  <> Options.value 1
-  )
+pnumWallets =
+  Options.option
+    Options.auto
+    ( Options.long "num-wallets"
+        <> Options.long "wallets"
+        <> Options.short 'n'
+        <> Options.metavar "NUM_WALLETS"
+        <> Options.value 1
+    )
 
 pdirWallets :: Parser (Maybe FilePath)
-pdirWallets = optional $ Options.strOption
-  (  Options.long "wallets-dir"
-  <> Options.long "wallet-dir"
-  <> Options.short 'd'
-  <> Options.metavar "FILEPATH"
-  )
+pdirWallets =
+  optional $
+    Options.strOption
+      ( Options.long "wallets-dir"
+          <> Options.long "wallet-dir"
+          <> Options.short 'd'
+          <> Options.metavar "FILEPATH"
+      )
 
 padaAmount :: Parser Integer
-padaAmount = Options.option Options.auto
-  (  Options.long "ada"
-  <> Options.short 'a'
-  <> Options.metavar "ADA"
-  <> Options.value 10_000
-  )
+padaAmount =
+  Options.option
+    Options.auto
+    ( Options.long "ada"
+        <> Options.short 'a'
+        <> Options.metavar "ADA"
+        <> Options.value 10_000
+    )
 
 plvlAmount :: Parser Integer
-plvlAmount = Options.option Options.auto
-  (  Options.long "lovelave"
-  <> Options.short 'l'
-  <> Options.metavar "Lovelace"
-  <> Options.value 0
-  )
+plvlAmount =
+  Options.option
+    Options.auto
+    ( Options.long "lovelace"
+        <> Options.short 'l'
+        <> Options.metavar "Lovelace"
+        <> Options.value 0
+    )
 
 pnumUtxos :: Parser Int
-pnumUtxos = Options.option Options.auto
-  (  Options.long "utxos"
-  <> Options.short 'u'
-  <> Options.metavar "NUM_UTXOS"
-  <> Options.value 1
-  )
+pnumUtxos =
+  Options.option
+    Options.auto
+    ( Options.long "utxos"
+        <> Options.short 'u'
+        <> Options.metavar "NUM_UTXOS"
+        <> Options.value 1
+    )
 
 pWorkDir :: Parser (Maybe FilePath)
-pWorkDir = optional $ Options.strOption
-  (  Options.long "working-dir"
-  <> Options.short 'w'
-  <> Options.metavar "FILEPATH"
-  )
+pWorkDir =
+  optional $
+    Options.strOption
+      ( Options.long "working-dir"
+          <> Options.short 'w'
+          <> Options.metavar "FILEPATH"
+      )
 
 pClusterConfig :: Parser CWalletConfig
-pClusterConfig = CWalletConfig
-  <$> pnumWallets
-  <*> pdirWallets
-  <*> padaAmount
-  <*> plvlAmount
-  <*> pnumUtxos
-  <*> pWorkDir
+pClusterConfig =
+  CWalletConfig
+    <$> pnumWallets
+    <*> pdirWallets
+    <*> padaAmount
+    <*> plvlAmount
+    <*> pnumUtxos
+    <*> pWorkDir
 
 -- | Basic info about the cluster, to
 -- be used by the command-line
 data CWalletConfig = CWalletConfig
-  { numWallets :: Int
-  , dirWallets :: Maybe FilePath
-  , adaAmount  :: Integer
-  , lvlAmount  :: Integer
-  , numUtxos :: Int
-  , workDir  :: Maybe FilePath
-  } deriving stock (Show, Eq)
-
+  { numWallets :: Int,
+    dirWallets :: Maybe FilePath,
+    adaAmount :: Integer,
+    lvlAmount :: Integer,
+    numUtxos :: Int,
+    workDir :: Maybe FilePath
+  }
+  deriving stock (Show, Eq)

--- a/local-cluster/Main.hs
+++ b/local-cluster/Main.hs
@@ -39,7 +39,7 @@ main = do
       (st, _) <- startCluster plutipConfig $ do
         ws <- initWallets numWallets numUtxos amt dirWallets
         waitSeconds 2 -- let wallet Tx finish, it can take more time with bigger slot length
-        
+
         separate
         liftIO $ forM_ (zip ws [(1 :: Int) ..]) printWallet
         printNodeRelatedInfo
@@ -58,7 +58,7 @@ main = do
 
     totalAmount :: CWalletConfig -> Either String Positive
     totalAmount cwc =
-      case toAda (adaAmount cwc) + lvlAmount cwc of
+      case toAda (abs $ adaAmount cwc) + abs (lvlAmount cwc) of
         0 -> Left "One of --ada or --lovelace arguments should not be 0"
         amt -> Right $ fromInteger amt
 

--- a/local-cluster/README.md
+++ b/local-cluster/README.md
@@ -58,11 +58,7 @@ This puts `AMOUNT` Lovelace into each UTxO in every wallet created, in addition 
 the amount specified by the `--ada` argument. Note that if you don't specify the
 amount of ADA to add, the total amount will be 10,000 ADA + `AMOUNT` lovelace.
 
-
-Note that for both `--ada` and `--lovelace`, the values' absolute values are taken
-and then added together to get the total amount to use for the UTxOs. Note that this
-means that if you use a command like `local-cluster --ada 5 --lovelace -1`, the final
-amount will be 5.000001 ADA instead of 4.999999 ADA.
+Note that both `--ada` and `--lovelace` can not be 0 at the same time.
 
 ```
 --utxos NUM

--- a/plutip.cabal
+++ b/plutip.cabal
@@ -241,5 +241,6 @@ executable local-cluster
     , mtl
     , optparse-applicative
     , plutip
+    , positive
 
   ghc-options:   -Wall -threaded -rtsopts


### PR DESCRIPTION
- fixed: parsing of --lovelace and --ada args
- minor refactoring

Reason: 
local-cluster executable fails with something like
```
cabal run local-cluster -- --wallets 2 --ada 100  --utxos 1
``` 
because omitted  `--lovelace` argument will fail parsing default `0` to `Positive`.

The fix is `totalAmount` function. Rest of diff is just refactoring.