### PR TITLE
Switch to non-segfaulting bpi

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -170,6 +170,6 @@ source-repository-package
 
 source-repository-package
     type: git
-    location: https://github.com/mlabs-haskell/bot-plutus-interface
-    tag: def9b215a974326eb7237df84bc4d07970c07294
-    --sha256: 00hpf3slbsnbzvgh4b92v7w0mppx8af3lxlyd14pk5rwysmgdh7r
+    location: https://github.com/jaredponn/bot-plutus-interface
+    tag: a17b38062eaa93f20ece085fb3d3ee340b0ff4ba
+    --sha256: bLEe9x/rNYxaZ+U1ue1AN/KvnuG2ZsADkcJcKdPLmIA=

--- a/flake.lock
+++ b/flake.lock
@@ -46,17 +46,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1667916204,
-        "narHash": "sha256-SIqFPS/yVtOnUZ5Wo2IvpYLR9nItkEQHhA7vfojMYvI=",
-        "owner": "mlabs-haskell",
+        "lastModified": 1668393527,
+        "narHash": "sha256-bLEe9x/rNYxaZ+U1ue1AN/KvnuG2ZsADkcJcKdPLmIA=",
+        "owner": "jaredponn",
         "repo": "bot-plutus-interface",
-        "rev": "9c7e06ec1b6911d5814982ef3dc563a8bc74909a",
+        "rev": "a17b38062eaa93f20ece085fb3d3ee340b0ff4ba",
         "type": "github"
       },
       "original": {
-        "owner": "mlabs-haskell",
+        "owner": "jaredponn",
         "repo": "bot-plutus-interface",
-        "rev": "9c7e06ec1b6911d5814982ef3dc563a8bc74909a",
+        "rev": "a17b38062eaa93f20ece085fb3d3ee340b0ff4ba",
         "type": "github"
       }
     },
@@ -210,11 +210,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1667351742,
-        "narHash": "sha256-pYeRspS/Ap+8NpxpljaXOTlstVsj+ENadvZKgzvI7nY=",
+        "lastModified": 1667438257,
+        "narHash": "sha256-CeiOpAForXQpBZQAr+jcZqjTTJ2mS7vS58wJ2tUD4Ps=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "9a40e696d964a16cdfa2e6198f498401995f21cc",
+        "rev": "db9e2f4270dd16e20e0bd2b1aada926bcc97042e",
         "type": "github"
       },
       "original": {
@@ -249,11 +249,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1667366313,
-        "narHash": "sha256-P12NMyexQDaSp5jyqOn4tWZ9XTzpdRTgwb7dZy1cTDc=",
+        "lastModified": 1667438430,
+        "narHash": "sha256-POHnQtfBdDJP2AHcmTnCC1qMhq81Plq7fuh2xhLCBs8=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "69a42f86208cbe7dcbfc32bc7ddde76ed8eeb5ed",
+        "rev": "3a7f069ccc491c783a28429aa8bcb504f70dc62b",
         "type": "github"
       },
       "original": {
@@ -513,11 +513,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1667351848,
-        "narHash": "sha256-gXjvvU0hW8NtbuFyCy+hzp669sEMAubS0zhMIPg/QOg=",
+        "lastModified": 1667438369,
+        "narHash": "sha256-5eB7phEMU/4+srICVQELeE1iiS2+PH0TQB+1TzKYmVo=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "128fd7fcb43c96ae422b4b1b3d485a40432848de",
+        "rev": "57d55a87a6711fe8f55c72891be757096dac7232",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,8 @@
       url = "github:edolstra/flake-compat";
       flake = false;
     };
-    bot-plutus-interface.url = github:mlabs-haskell/bot-plutus-interface/9c7e06ec1b6911d5814982ef3dc563a8bc74909a;
+
+    bot-plutus-interface.url = github:jaredponn/bot-plutus-interface/a17b38062eaa93f20ece085fb3d3ee340b0ff4ba;
   };
 
   outputs =


### PR DESCRIPTION
This can mostly be ignored. For motivation for why this is here, see https://github.com/mlabs-haskell/trustless-sidechain/pull/272