### PR TITLE
Plutip server fixes

### DIFF
--- a/plutip-server/Types.hs
+++ b/plutip-server/Types.hs
@@ -48,7 +48,7 @@ import UnliftIO.STM (TVar)
 -- cluster at any given moment).
 -- This MVar is used by start/stop handlers.
 -- The payload of ClusterStatus is irrelevant.
-type ClusterStatusRef = MVar (TVar (ClusterStatus (ClusterEnv, Either Text [BpiWallet])))
+type ClusterStatusRef = MVar (TVar (ClusterStatus (ClusterEnv, [BpiWallet])))
 
 data Env = Env
   { status :: ClusterStatusRef

--- a/plutip-server/Types.hs
+++ b/plutip-server/Types.hs
@@ -3,7 +3,8 @@ module Types (
   ClusterStartupFailureReason (
     ClusterIsRunningAlready,
     NegativeLovelaces,
-    NodeConfigNotFound
+    NodeConfigNotFound,
+    WaitingForFundedWalletsFailed
   ),
   Env (Env, status, options),
   ErrorMessage,
@@ -37,14 +38,7 @@ import Data.Text (Text)
 import GHC.Generics (Generic)
 import Network.Wai.Handler.Warp (Port)
 import Test.Plutip.Internal.BotPlutusInterface.Wallet (BpiWallet)
-import Test.Plutip.Internal.LocalCluster (
-  ClusterStatus (
-    ClusterClosed,
-    ClusterClosing,
-    ClusterStarted,
-    ClusterStarting
-  ),
- )
+import Test.Plutip.Internal.LocalCluster (ClusterStatus)
 import Test.Plutip.Internal.Types (ClusterEnv)
 import UnliftIO.STM (TVar)
 
@@ -54,7 +48,7 @@ import UnliftIO.STM (TVar)
 -- cluster at any given moment).
 -- This MVar is used by start/stop handlers.
 -- The payload of ClusterStatus is irrelevant.
-type ClusterStatusRef = MVar (TVar (ClusterStatus (ClusterEnv, [BpiWallet])))
+type ClusterStatusRef = MVar (TVar (ClusterStatus (ClusterEnv, Either Text [BpiWallet])))
 
 data Env = Env
   { status :: ClusterStatusRef
@@ -111,6 +105,7 @@ data ClusterStartupFailureReason
   = ClusterIsRunningAlready
   | NegativeLovelaces
   | NodeConfigNotFound
+  | WaitingForFundedWalletsFailed Text
   deriving stock (Show, Eq, Generic)
   deriving anyclass (FromJSON, ToJSON)
 

--- a/plutip-server/Types.hs
+++ b/plutip-server/Types.hs
@@ -3,8 +3,7 @@ module Types (
   ClusterStartupFailureReason (
     ClusterIsRunningAlready,
     NegativeLovelaces,
-    NodeConfigNotFound,
-    WaitingForFundedWalletsFailed
+    NodeConfigNotFound
   ),
   Env (Env, status, options),
   ErrorMessage,
@@ -105,7 +104,6 @@ data ClusterStartupFailureReason
   = ClusterIsRunningAlready
   | NegativeLovelaces
   | NodeConfigNotFound
-  | WaitingForFundedWalletsFailed Text
   deriving stock (Show, Eq, Generic)
   deriving anyclass (FromJSON, ToJSON)
 

--- a/plutip.cabal
+++ b/plutip.cabal
@@ -203,6 +203,7 @@ executable plutip-server
   default-language: Haskell2010
   build-depends:
     , aeson
+    , async
     , base
     , base16-bytestring
     , bytestring

--- a/src/Test/Plutip/Internal/LocalCluster.hs
+++ b/src/Test/Plutip/Internal/LocalCluster.hs
@@ -11,9 +11,9 @@ module Test.Plutip.Internal.LocalCluster (
 ) where
 
 import Cardano.Api qualified as CAPI
+import Cardano.BM.Configuration.Model qualified as CM
 import Cardano.BM.Data.Severity qualified as Severity
 import Cardano.BM.Data.Tracer (HasPrivacyAnnotation, HasSeverityAnnotation (getSeverityAnnotation))
-import Cardano.BM.Configuration.Model qualified as CM
 import Cardano.CLI (LogOutput (LogToFile), withLoggingNamed)
 import Cardano.Launcher.Node (nodeSocketFile)
 import Cardano.Startup (installSignalHandlers, setDefaultFilePermissions, withUtf8Encoding)

--- a/src/Test/Plutip/Tools/CardanoApi.hs
+++ b/src/Test/Plutip/Tools/CardanoApi.hs
@@ -5,6 +5,7 @@ module Test.Plutip.Tools.CardanoApi (
   queryProtocolParams,
   queryTip,
   awaitWalletFunded,
+  AwaitWalletFundedError (AwaitingCapiError, AwaitingTimeoutError),
 ) where
 
 import Cardano.Api qualified as C
@@ -18,8 +19,6 @@ import Control.Retry (constantDelay, limitRetries, retrying)
 import Data.Either (fromRight)
 import Data.Map qualified as M
 import Data.Set qualified as Set
-import Data.Text (Text)
-import Data.Text qualified as T
 import GHC.Generics (Generic)
 import Ouroboros.Consensus.HardFork.Combinator.AcrossEras (EraMismatch)
 import Ouroboros.Network.Protocol.LocalStateQuery.Type (AcquireFailure)
@@ -79,13 +78,21 @@ flattenQueryResult = \case
   Right (Right res) -> Right res
   err -> Left $ SomeError (show err)
 
+data AwaitWalletFundedError
+  = AwaitingCapiError CardanoApiError
+  | AwaitingTimeoutError
+
+instance Show AwaitWalletFundedError where
+  show (AwaitingCapiError (SomeError e)) = e
+  show AwaitingTimeoutError = "Awaiting funding transaction timed out."
+
 -- | Waits till specified address is funded using cardano-node query.
 -- Performs 20 tries with 0.2 seconds between tries, which should be a sane default.
 -- Waits till there's any utxos at an address - works for us as funds will be send with tx per address.
 awaitWalletFunded ::
   ClusterEnv ->
   C.AddressAny ->
-  IO (Either Text ())
+  IO (Either AwaitWalletFundedError ())
 awaitWalletFunded cenv addr = toErrorMsg <$> retrying policy checkResponse action
   where
     -- With current defaults the slot length is 0.2s and block gets produced about every second slot.
@@ -98,8 +105,8 @@ awaitWalletFunded cenv addr = toErrorMsg <$> retrying policy checkResponse actio
     checkResponse _ = return . fromRight False
 
     toErrorMsg = \case
-      Left (SomeError e) -> Left $ T.pack e
+      Left e -> Left $ AwaitingCapiError e
       Right noUtxos ->
         if noUtxos
-          then Left "Funding transaction wasn't submitted yet and we're done waiting."
+          then Left AwaitingTimeoutError
           else Right ()

--- a/test/Spec/Integration.hs
+++ b/test/Spec/Integration.hs
@@ -188,7 +188,7 @@ test =
           (initAda [100])
           (withContract $ const failingTimeContract)
           [shouldFail] -- FIXME: add check that "OutsideValidityIntervalUTxO" is in error message
-          -- [shouldSucceed] 
+          -- [shouldSucceed]
       , assertExecution
           "Passes validation with exact time range checks"
           (initAda [100])


### PR DESCRIPTION
 * Fixes #152 and #153.
 * Fixes waiting for wallets to get funded <- ports a fix that exists in more recent commits, only here using cardano-node queries and only applied in plutip-server. *EDIT*:  In this pr we ignore timeout error: returning from `startCluster` handler doesn't guarantee that wallets are funded. Waiting properly for the funds takes strangely long time. Im leaving fixing this out of this pr, but this is no worse than before when we waited for 2 seconds. 
 * Retries cluster 5 times if startup fails (with the aim to dodge rare bug in finding available ports for cardano-nodes)
 
 I reproduced the cluster startup failure using forked cluster which always chose unavailable ports. This hits " resource busy (Address already in use)"  when cardano-node picks used up port due to a race condition. Retrying aims to make this case very rare. 