### PR TITLE
fix: check -threaded is set [2]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ result*
 
 #vscode
 .vscode/
+
+# local files created by the cluster
+local-cluster-info.json

--- a/flake.nix
+++ b/flake.nix
@@ -182,7 +182,7 @@
       flake = perSystem (system: (projectFor system).flake { });
 
       defaultPackage = perSystem (system:
-        let lib = "plutip:lib:plutip";
+        let lib = "plutip-core:lib:plutip-core";
         in self.flake.${system}.packages.${lib});
 
       packages = perSystem (system: self.flake.${system}.packages);

--- a/src/Plutip/Cluster.hs
+++ b/src/Plutip/Cluster.hs
@@ -265,8 +265,8 @@ withEnvironmentSetup conf action = do
         fromMaybe defaultClusterDataDir (clusterDataDir conf)
 
     checkRtsSettings =
-      unless rtsSupportsBoundThreads
-        $ die "Plutip executable should be compiled with `-threaded` flag."
+      unless rtsSupportsBoundThreads $
+        die "Plutip executable should be compiled with `-threaded` flag."
 
 checkProcessesAvailable :: [String] -> IO ()
 checkProcessesAvailable requiredProcesses = do


### PR DESCRIPTION
Moved from #173

- Check that `-threaded` is set before spawning cluster.
- Fix misspelling "plutip" -> "plutip-core" in flake